### PR TITLE
Add support for the Ordered, Preparing, Shipped device statuses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 before_install:
   - npm -g install npm@6
 node_js:
-  - "12"
   - "10"
   - "8"
 notifications:

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -47,6 +47,9 @@ export const status = {
 	INACTIVE: 'inactive',
 	POST_PROVISIONING: 'post-provisioning',
 	UPDATING: 'updating',
+	ORDERED: 'ordered',
+	PREPARING: 'preparing',
+	SHIPPED: 'shipped',
 } as const;
 
 /**
@@ -64,6 +67,9 @@ export const statuses: Status[] = [
 	{ key: status.OFFLINE, name: 'Offline' },
 	{ key: status.POST_PROVISIONING, name: 'Post Provisioning' },
 	{ key: status.INACTIVE, name: 'Inactive' },
+	{ key: status.ORDERED, name: 'Ordered' },
+	{ key: status.PREPARING, name: 'Preparing' },
+	{ key: status.SHIPPED, name: 'Shipped' },
 ];
 
 /**
@@ -93,6 +99,15 @@ const statusesByKey = keyBy(statuses, 'key');
  * 		console.log(status.name)
  */
 export const getStatus = (device: Device) => {
+	if (
+		device.status === 'Ordered' ||
+		device.status === 'Preparing' ||
+		(!device.is_online && device.status === 'Shipped')
+	) {
+		const currentStatus = statuses.find(s => s.name === device.status)!;
+		return currentStatus;
+	}
+
 	if (!device.is_active) {
 		return statusesByKey[status.INACTIVE];
 	}

--- a/tests/status.spec.coffee
+++ b/tests/status.spec.coffee
@@ -61,6 +61,57 @@ describe 'Status', ->
 
 	describe '.getStatus()', ->
 
+		[
+			{ active: false, online: false }
+			{ active: false, online: true }
+			{ active: true, online: false }
+			{ active: true, online: true }
+		].forEach ({ active, online }) ->
+			it "should return ORDERED if the status is Ordered and is_active is #{active} and is_online is #{online}", ->
+				device = getDeviceMock
+					is_active: active
+					is_online: online
+					status: 'Ordered'
+
+				m.chai.expect(status.getStatus(device)).to.deep.equal
+					key: 'ordered'
+					name: 'Ordered'
+
+			it "should return PREPARING if the status is Preparing and is_active is #{active} and is_online is #{online}", ->
+				device = getDeviceMock
+					is_active: active
+					is_online: online
+					status: 'Preparing'
+
+				m.chai.expect(status.getStatus(device)).to.deep.equal
+					key: 'preparing'
+					name: 'Preparing'
+
+		[
+			{ active: false }
+			{ active: true }
+		].forEach ({ active, online }) ->
+
+			it "should return SHIPPED if the status is Shipped and is_active is #{active} and is_online is false", ->
+				device = getDeviceMock
+					is_active: true
+					is_online: false
+					status: 'Shipped'
+
+				m.chai.expect(status.getStatus(device)).to.deep.equal
+					key: 'shipped'
+					name: 'Shipped'
+
+		it 'should not return SHIPPED if the status is Shipped and is_online is true', ->
+			device = getDeviceMock
+				is_active: true
+				is_online: true
+				status: 'Shipped'
+
+			m.chai.expect(status.getStatus(device)).to.deep.equal
+				key: 'idle'
+				name: 'Online'
+
 		it 'should return INACTIVE if is_active is false and the device was not seen', ->
 			device = getDeviceMock
 				is_active: false


### PR DESCRIPTION
Change-type: minor
See: https://github.com/balena-io/resin-ui/issues/3137
See: https://github.com/balena-io-modules/balena-image-manager/pull/45/commits/c2618f4e55eacc79e1ed9883d1560c0d5009e905
See: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/-tyqYB2AROfEXyGUzQ_t0H3K-aC
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>