### PR TITLE
Deprecate balena-device-status in favor of API field

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 balena-device-status
 ===================
 
-> Balena device status interpreter
+**DEPRECATED** - Use the `overall_status` field on the `device` resource instead.
 
 [![npm version](https://badge.fury.io/js/balena-device-status.svg)](http://badge.fury.io/js/balena-device-status)
 [![dependencies](https://david-dm.org/balena-io-modules/balena-device-status.svg)](https://david-dm.org/balena-io-modules/balena-device-status.svg)
 [![Build Status](https://travis-ci.org/balena-io-modules/balena-device-status.svg?branch=master)](https://travis-ci.org/balena-io-modules/balena-device-status)
 [![Build status](https://ci.appveyor.com/api/projects/status/2t0yxu6971bjd4xa/branch/master?svg=true)](https://ci.appveyor.com/project/resin-io/balena-device-status/branch/master)
 
-[![Sauce Test Status](https://saucelabs.com/browser-matrix/balena-device-status.svg)](https://saucelabs.com/u/balena-device-status)
+> Balena device status interpreter
 
 Role
 ----


### PR DESCRIPTION
We have now added support for overall_status in the API,
which is the same calculation that balena-device-status did.
This renders the library unnecessary, so we won't be doing
any further changes to it.

Once this is merged, we need to prepend `[DEPRECATED]` to the project description.

Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>